### PR TITLE
Allowing passing through of onLayout prop rather than overwriting

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -22,11 +22,15 @@ export default class LinearGradient extends PureComponent {
     height: 1,
   };
 
-  measure = ({ nativeEvent }) =>
+  measure = (event) => {
     this.setState({
-      width: nativeEvent.layout.width,
-      height: nativeEvent.layout.height,
+      width: event.nativeEvent.layout.width,
+      height: event.nativeEvent.layout.height,
     });
+    if (this.props.onLayout) {
+      this.props.onLayout(event);
+    }
+  }
 
   getAngle = () => {
     if (this.props.useAngle) {


### PR DESCRIPTION
Currently the `onLayout` prop of the main `View` that is used gets the `measure` function assigned to it.

As this happens after remaining props are spread into the `View`, if a user has passed `onLayout` in themselves, it is ignored.

As a fix, I'm calling `this.props.onLayout` inside the `measure` function (if it exists).